### PR TITLE
[BRI-855] change use of js keyword 'interface' -> 'abiInterface'

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -111,9 +111,9 @@ function createVerifierDef (pkgName, contractName, contractAddress, functionName
   const artifact = require(`@brinkninja/${pkgName}/artifacts/contracts/Verifiers/${contractName}.sol/${contractName}.json`)
   const fnDef = _.find(artifact.abi, { name: functionName })
 
-  const interface = new ethers.utils.Interface(artifact.abi)
+  const abiInterface = new ethers.utils.Interface(artifact.abi)
   const functionSignature = ethers.utils.FunctionFragment.from(fnDef).format()
-  const functionSignatureHash = interface.getSighash(functionSignature)
+  const functionSignatureHash = abiInterface.getSighash(functionSignature)
 
   const paramTypes = fnDef.inputs.map((input, i) => {
     let paramDef = {


### PR DESCRIPTION
The @brinkninja/config package has 2 lines of code that uses `interface`, which is a reserved word in JavaScript now when in strict mode (i.e. `use strict';`, which webpack uses by default). The latest config in the new web repo in strict mode is causing the build to fail due to the incorrect use of `interface`. 

Console logs:
```
web:build: Caused by:
web:build:     0: failed to parse input file
web:build:     1: Syntax Error
web:build: Error:
web:build:   x `interface` cannot be used as an identifier in strict mode
web:build:         ,-[109890:1]
web:build:  109890 |   const artifact = __webpack_require__(42319)(`./${pkgName}/artifacts/contracts/Verifiers/${contractName}.sol/${contractName}.json`)
web:build:  109891 |   const fnDef = _.find(artifact.abi, { name: functionName })
web:build:  109892 |
web:build:  109893 |   const interface = new ethers.utils.Interface(artifact.abi)
web:build:         :         ^^^^^^^^^
web:build:  109894 |   const functionSignature = ethers.utils.FunctionFragment.from(fnDef).format()
web:build:  109895 |   const functionSignatureHash = interface.getSighash(functionSignature)
web:build:         `----
web:build:
web:build:   x Expression expected
web:build:         ,-[109892:1]
web:build:  109892 |
web:build:  109893 |   const interface = new ethers.utils.Interface(artifact.abi)
web:build:  109894 |   const functionSignature = ethers.utils.FunctionFragment.from(fnDef).format()
web:build:  109895 |   const functionSignatureHash = interface.getSighash(functionSignature)
web:build:         :                                 ^^^^^^^^^
web:build:  109896 |
web:build:  109897 |   const paramTypes = fnDef.inputs.map((input, i) => {
web:build:  109898 |     let paramDef = {
web:build:         `----
```
